### PR TITLE
Fix WebSocket CORS default behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,7 @@ The system uses SQLite database and stores configuration in the database. Key se
 - **Gmail**: OAuth2 authentication for receipt processing
 - **CORS_ORIGIN**: Set to your frontend URL (e.g. `http://localhost:3000`) to
   allow the panel to connect to the WebSocket API. Use `*` to allow all origins.
+  When using `*`, credentials are disabled automatically, so send auth tokens in
+  the request payload.
 
 This project was created using `bun init` in bun v1.2.2. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/src/webserver/server.ts
+++ b/src/webserver/server.ts
@@ -65,14 +65,17 @@ export class WebSocketServer {
       corsOrigin === '*'
         ? '*'
         : corsOrigin.split(',').map((o) => o.trim());
+    // If CORS is set to wildcard, credentials cannot be enabled
+    const allowCredentials = corsOrigin !== '*';
 
     this.io = new Server(this.httpServer, {
       cors: {
         origin: allowedOrigins,
         methods: ['GET', 'POST'],
-        credentials: true,
+        credentials: allowCredentials,
       },
     });
+    logger.info('Configured CORS', { allowedOrigins, credentials: allowCredentials });
 
     this.setupMiddleware();
     this.setupEventHandlers();


### PR DESCRIPTION
## Summary
- adjust WebSocket server so credentials are disabled when `CORS_ORIGIN` is `*`
- document CORS behaviour in README

## Testing
- `bun test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_685e6c0b6cc4832096abe0a8b118dcfe