### PR TITLE
Fix CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,5 +32,5 @@ PORT="3000"
 
 # WebSocket Server
 WEBSOCKET_PORT="3002"
-CORS_ORIGIN="http://localhost:3000"
+CORS_ORIGIN="*"
 JWT_SECRET="your-secret-key-change-in-production"

--- a/README.md
+++ b/README.md
@@ -83,9 +83,8 @@ The system uses SQLite database and stores configuration in the database. Key se
 - **Mode**: `manual` or `automatic` - controls whether user confirmation is required
 - **Exchange Rate**: Can be set to constant or automatic mode
 - **Gmail**: OAuth2 authentication for receipt processing
-- **CORS_ORIGIN**: Set to your frontend URL (e.g. `http://localhost:3000`) to
-  allow the panel to connect to the WebSocket API. Use `*` to allow all origins.
-  When using `*`, credentials are disabled automatically, so send auth tokens in
-  the request payload.
+- **CORS_ORIGIN**: Comma-separated list of allowed origins. Example:
+  `http://147.45.71.51:3000,http://localhost:3000`. The default `*` allows any
+  origin but disables credentials, so send auth tokens in the request payload.
 
 This project was created using `bun init` in bun v1.2.2. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.


### PR DESCRIPTION
## Summary
- allow any origin by default in `.env.example`
- document new CORS setting in README

## Testing
- `bun test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_685e70a74c9c8320a7ab5226a8232184